### PR TITLE
Switch to github.com/atotto/clipboard, fix security bug on windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,15 @@ module localsend_cli
 
 go 1.22
 
-require github.com/prometheus-community/pro-bing v0.4.0
+require (
+	github.com/atotto/clipboard v0.1.4
+	github.com/prometheus-community/pro-bing v0.4.0
+	gopkg.in/yaml.v2 v2.4.0
+)
 
 require (
 	github.com/google/uuid v1.6.0 // indirect
 	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/prometheus-community/pro-bing v0.4.0 h1:YMbv+i08gQz97OZZBwLyvmmQEEzyfyrrjEaAchdy3R4=
@@ -8,6 +10,7 @@ golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
 golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
 golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -6,47 +6,23 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"runtime"
-	"strings"
+
+	"github.com/atotto/clipboard"
 )
 
 func CheckOSType() string {
 	return runtime.GOOS
 }
 func WriteToClipBoard(text string) {
-	os := CheckOSType()
-	switch os {
-	case "linux":
-		cmd := exec.Command("xclip", "-selection", "clipboard")
-		cmd.Stdin = strings.NewReader(text)
-		err := cmd.Run()
-		if err != nil {
-			fmt.Printf("Error copying to clipboard on Linux: %v\n", err)
-		} else {
-			fmt.Println("Text copied to clipboard on Linux!")
-		}
-	case "windows":
-		cmd := exec.Command("cmd", "/c", "echo "+text+" | clip")
-		err := cmd.Run()
-		if err != nil {
-			fmt.Printf("Error copying to clipboard on Windows: %v\n", err)
-		} else {
-			fmt.Println("Text copied to clipboard on Windows!")
-		}
-	case "darwin":
-		cmd := exec.Command("pbcopy")
-		cmd.Stdin = strings.NewReader(text)
-		err := cmd.Run()
-		if err != nil {
-			fmt.Printf("Error copying to clipboard on macOS: %v\n", err)
-		} else {
-			fmt.Println("Text copied to clipboard on macOS!")
-		}
-	default:
-		fmt.Printf("Unsupported OS: %v\n", os)
+	err := clipboard.WriteAll(text)
+	if err != nil {
+		fmt.Printf("Error copying to clipboard: %v\n", err)
+	} else {
+		fmt.Println("Text copied to clipboard!")
 	}
 }
+
 func CalculateSHA256(filePath string) (string, error) {
 	file, err := os.Open(filePath)
 	if err != nil {


### PR DESCRIPTION
I think the current code for `WriteToClipBoard` on Windows basically allows an attacker to run any commands on your system by sending a text (arbitrary code execution).

And this is done without confirmation (auto-accept).

You should never construct a shell command from user input without proper quoting / escaping.